### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@sailshq/lodash": "^3.10.2",
     "machine": "^15.0.0-0",
-    "machinepack-urls": "^6.0.0-2",
+    "machinepack-urls": "^6.0.2-0",
     "request": "2.85.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@sailshq/lodash": "^3.10.2",
     "machine": "^15.0.0-0",
     "machinepack-urls": "^6.0.2-0",
-    "request": "2.85.0"
+    "request": "2.88.0"
   },
   "devDependencies": {
     "eslint": "4.11.0",


### PR DESCRIPTION
Upgraded from machinepack-urls@^6.0.0-2 to machinepack-urls@^6.0.2-0. This resolves a few security vulnerabilities coming from the old version.

This codebase is only using the `resolve` machine from machinepack-urls, and between my installed version (6.0.1) and the new version, the only change to that machine was the removal of an unused `require()`: https://github.com/sailshq/machinepack-urls/compare/v6.0.1..v6.0.2-0#diff-cda643a2f6294ad937e41516e5d86e3aL77

Tested the two affected machines (`sendHttpRequest` and `getStream`) in the node repl (after adding a `console.log()` to both machines to log the resolved target URL) and both worked as expected.